### PR TITLE
update matchbox

### DIFF
--- a/SRS_Relative.txt
+++ b/SRS_Relative.txt
@@ -1,1 +1,1 @@
-jwaldmann/termcomp2025-mbox:31-07-2025 cert
+jwaldmann/termcomp2025-mbox:05-08-2025 cert

--- a/SRS_Standard.txt
+++ b/SRS_Standard.txt
@@ -1,1 +1,1 @@
-jwaldmann/termcomp2025-mbox:31-07-2025 cert
+jwaldmann/termcomp2025-mbox:05-08-2025 cert


### PR DESCRIPTION
repaired cert failures (at least for SRS-standard)

expected behaviour: mostly CERTIFIED, some UNSUPPORTED (when matchbox does not finish to print the certificate)