### PR TITLE
Update C-category Docker image tag for memory-safety fix

### DIFF
--- a/C.txt
+++ b/C.txt
@@ -1,2 +1,2 @@
 nlommen/aprove_koat_loat:578822
-takumamonma/coar:termcomp2026
+takumamonma/coar:termcomp2026_v2


### PR DESCRIPTION
This PR updates the Docker image tag for the C category.

The new image fixes a bug in the handling of memory safety verification. Previously, the tool could report YES or NO even when memory safety could not be established. After the fix, such cases are reported as MAYBE.

In our benchmark run, 28 results changed from YES or NO to MAYBE.

This update addresses only this memory safety-related output bug. The other errors identified in the previous image are not addressed in this PR.

This is a correctness fix to the reported results and does not improve the termination analysis itself.